### PR TITLE
Fix streaming NOT working with port != 80

### DIFF
--- a/plugin/httpserver.py
+++ b/plugin/httpserver.py
@@ -75,10 +75,10 @@ def buildRootTree(session):
 				
 			if not os.path.exists(origwebifpath + "/WebChilds/External"):
 				os.makedirs(origwebifpath + "/WebChilds/External")
-			open(origwebifpath + "/__init__.py", "w")
-			open(origwebifpath + "/WebChilds/__init__.py", "w")
-			open(origwebifpath + "/WebChilds/External/__init__.py", "w")
-			
+			open(origwebifpath + "/__init__.py", "w").close()
+ 			open(origwebifpath + "/WebChilds/__init__.py", "w").close()
+ 			open(origwebifpath + "/WebChilds/External/__init__.py", "w").close()
+
 			os.symlink(hookpath, origwebifpath + "/WebChilds/Toplevel.py")
 			
 		# import modules


### PR DESCRIPTION
Note that "NOT working" means "it didn't work". I mean "really didn't work".

This is not the same error as
- streamproxy bypassing the login although stream auth is enabled
  or the opposite
- streamproxy asking for login while stream auth is disabled.

The third person reporting an unwanted login query as "doesn't work" gets shot ... and two have already been there ...
