### PR TITLE
Dirty workaround for a bug in most versions of EPGRefresh

### DIFF
--- a/plugin/public/js/epgr.js
+++ b/plugin/public/js/epgr.js
@@ -165,10 +165,10 @@ function readEPGR2(chbq)
 					else
 						$('#er_'+name).val(val);
 				}
-				else {
-					if(name === "hasAutoTimer" && val === "True")
-						er_hasAutoTimer = true;
-				}
+				//else {
+				//	if(name === "hasAutoTimer" && val === "True")
+				//		er_hasAutoTimer = true;
+				//}
 			});
 			
 			UpdateCHBQ(chbq,begin,end);


### PR DESCRIPTION
EPGRefresh claims to have autotimer-integration but doesn't.
